### PR TITLE
Fix out-of-bound access in E_hairpin() and vrna_E_stack() of ViennaRNA

### DIFF
--- a/src/counting.inc
+++ b/src/counting.inc
@@ -107,7 +107,7 @@ void get_partition_function(TYPE * partition_function, plain_sequence * rna){
 	  current_base_pair=current_flat_structure->current;
 	  i=get_flat_structure_start(current_base_pair);
 	  j=get_flat_structure_end(current_base_pair); 
-      if ((i==x) && (j==y) && !is_entirely_contained(i,j,rna)){ /* exception to cases where i=1 OR j=rna->size */
+      if ((i==x) && (j==y) && (!is_entirely_contained(i,j,rna)) && (!((j == rna->size) || (i == 1)))){ /* exception to cases where i=1 OR j=rna->size */
 	    /* thickness= 1 */
 	    apply_energy_term(&partition_fci, stacking_energy(x-1,y+1), partition_function_table[x+1][y-1]); /* yann */
         add_link_element(linktable, DOUBLE_CAST(partition_fci), current_flat_structure);

--- a/src/energies.c
+++ b/src/energies.c
@@ -177,16 +177,17 @@ double internal_loop_energy(int i, int k, int l, int j, plain_sequence *rna){
 double hairpin_energy(int i, int j, plain_sequence * rna){
   double hairpin_energy;
   int hsize, ptype;
-  char *hseq; /* sequence of unpaired bases in hairpin */
+  char hseq[10]; /* sequence of unpaired bases in hairpin */
   hsize = j - i - 1;
   ptype = get_type(rna->label[i], rna->label[j]);
-  hseq = (char*) malloc ((hsize+1)*sizeof(char));
-  strncpy(hseq, rna->label+i+1, hsize);
-  hseq[hsize] = '\0';
+  hseq[0] = '\0';
+  if (hsize < 7) {
+    strncpy(&(hseq[0]), rna->label+i-1, hsize + 2);
+    hseq[hsize + 2] = '\0';
+  }
   hairpin_energy = E_Hairpin(hsize, ptype, E_fold_cp->sequence_encoding[i+1], E_fold_cp->sequence_encoding[j-1], hseq, E_fold_cp->params);
   //hairpin_energy = vrna_E_hp_loop(E_fold_cp, i, j);
   //printf("ptype: %d, energy: %f, hseq: %s, hsize: %d\n", ptype, hairpin_energy, hseq, hsize);
-  free(hseq);
   return hairpin_energy;
 }
 


### PR DESCRIPTION
...library

I've discovered two out-of-bounds memory access errors RNANR produced when using RNAlib.
Both stem from free energy evaluations, one for hairpins the other for base pair stacks.

1. For hairpins, the (short) sequence that needs to be supplied to `E_Hairpin()` is only required for Tri-, Tetra-, and Hexa-loop lookups. Thus, the sequence only needs to be at most 8nt in length. Note here, that one has to slice the hairpin loop sequence including the nucleotides of enclosing base pair! Therefore, my fix in `energies.c` has two changes. One, we do not dynamically allocate memory for the sequence string but use a static size char array. Second, we only copy-over the string if the length is short enough. Third, we copy including the enclosing base pair.

2. The second change is for stacking energies, where the previous conditional check using `is_entirely_contained()` is not sufficient. This function only checks whether i AND j are both start and end of the sequence. However, even if just one of them is at the sequence ends, i.e. 5' OR 3', no stack can be formed with an enclosing pair.
