### PR TITLE
Fix GMP random number generator initialization

### DIFF
--- a/src/counting_mpfr.c
+++ b/src/counting_mpfr.c
@@ -68,7 +68,8 @@ mpfr_rnd_t default_rnd(){  // returns default rounding mode (to nearest)
 #define CLEAR(a) mpfr_clear(a)
 #define TYPE_PRINT(a) mpfr_out_str(stdout, 10, 0, a, default_rnd()); // double only!  
 #define DOUBLE_CAST(a) mpfr_get_d(a, default_rnd()) // casts TYPE to double. 
-#define INIT_RNG() gmp_randinit_default (rng_state);  // initiates RNG
+#define INIT_RNG() gmp_randinit_default (rng_state); \
+                   gmp_randseed_ui(rng_state, (unsigned long) time(NULL)); // initiates RNG
 #define RANDOM_NUMBER(r, upper_bound) mpfr_urandomb(r, rng_state);\
                                       mpfr_mul(r,r, upper_bound, default_rnd())  
 


### PR DESCRIPTION
Unfortunately, the GMP random number generator used by the `mpfr_urandomb()` functions was not entirely initialized. For GMP, one not only needs to call `gmp_randinit_default()` to initialize the state variable, but in addition the seed must be explicitly set via `gmp_randseed()` to provide different seeds with each call of the program. Otherwise, when using the `-w` option, `RNANR` would always produce the same result for the same input sequence.

This patch fixes this behavior by initializing the seed with the current UNIX time.